### PR TITLE
fix: add types

### DIFF
--- a/packages/astro-google-fonts-optimizer/index.d.ts
+++ b/packages/astro-google-fonts-optimizer/index.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/astro-jsx" />
+export { default as GoogleFontsOptimizer } from "./GoogleFontsOptimizer.astro";

--- a/packages/astro-google-fonts-optimizer/package.json
+++ b/packages/astro-google-fonts-optimizer/package.json
@@ -4,6 +4,7 @@
   "version": "0.2.1",
   "private": false,
   "type": "module",
+  "types": "index.d.ts",
   "homepage": "https://github.com/sebholstein/astro-google-fonts-optimizer",
   "exports": {
     ".": "./index.js",
@@ -12,6 +13,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "font-utils.ts",
     "GoogleFontsOptimizer.astro",
     "../../README.md"


### PR DESCRIPTION
Packages that are using Astro with typescript would get an error when trying to build their code when using `astro-google-fonts-optimizer`: ![image](https://user-images.githubusercontent.com/19153565/188274645-1b39a9da-6b3e-466c-9708-4eb4458838bf.png). 
The types definition could be added on the consumer site but it's more developer friendly to keep them on package level. This PR adds index.d.ts file based on astro image types:
![imageTypes](https://user-images.githubusercontent.com/19153565/188274564-5d1f92cb-d2f4-42e2-b600-e5c8a496f675.png)

After adding the types VSCode is able to show type definition and the astro build start passing:

![types](https://user-images.githubusercontent.com/19153565/188274529-470e79d7-bce2-4d24-8437-55f570e94a60.gif)
