### PR TITLE
Update GoogleFontsOptimizer.astro to remove type from style element

### DIFF
--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -13,7 +13,7 @@ const contents = await Promise.all(urls.map(url => downloadFontCSS(url)))
 {contents.length > 0 &&
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />}
 {contents.map(styles => <>
-    <style type="text/css" set:html={styles} is:inline>
+    <style set:html={styles} is:inline>
     </style>
 </>
 )}


### PR DESCRIPTION
I have warning on https://validator.w3.org/

Warning: The type attribute for the style element is not needed and should be omitted.

From line 9, column 1; to line 9, column 23

onymous">↩<style type="text/css">@font-