### PR TITLE
Error handling on download fonts [SSR]

### DIFF
--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -14,7 +14,7 @@ import { GoogleFontsOptimizer } from "astro-google-fonts-optimizer";
 </head>
 
 <body style="font-family: 'Inter'">
-	Hello wolrd!
+	Hello world!
 </body>
 
 </html>

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -7,7 +7,7 @@ export interface Props {
 const props = Astro.props as Props;
 const urls = Array.isArray(props.url) ? props.url : [props.url];
 
-const contents = await Promise.all(urls.map(url => downloadFontCSS(url)))
+const contents = await Promise.all(urls.map(url => downloadFontCSS(url))).catch(() => [])
 ---
 
 {contents.length > 0 &&

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -7,13 +7,29 @@ export interface Props {
 const props = Astro.props as Props;
 const urls = Array.isArray(props.url) ? props.url : [props.url];
 
-const contents = await Promise.all(urls.map(url => downloadFontCSS(url))).catch(() => [])
+const contents = await Promise.all(
+    urls.map(async (url) => {
+        try {
+            const css = await downloadFontCSS(url);
+            return { css }
+        } catch (err) {
+            return { url }
+        }
+    })
+)
 ---
 
 {contents.length > 0 &&
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />}
-{contents.map(styles => <>
-    <style set:html={styles} is:inline>
-    </style>
-</>
-)}
+{contents.map(content => {
+    if (content.css) {
+        return (
+            <>
+                <style set:html={content.css} is:inline>
+                </style>
+            </>
+        )
+    }
+
+    return <link href={content.url} rel="stylesheet" />
+})}

--- a/packages/astro-google-fonts-optimizer/font-utils.ts
+++ b/packages/astro-google-fonts-optimizer/font-utils.ts
@@ -15,7 +15,12 @@ export function downloadFontCSS(url: string): Promise<string> {
   const fontDownloads = Promise.all(
     userAgents.map((entry) => {
       return fetch(url, { headers: { 'User-Agent': entry.ua } })
-        .then((res) => res.text())
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(res.statusText);
+          }
+          return res.text();
+        })
         .then((t) =>
           t.replace(/  +/g, '').replace(/\t+/g, '').replace(/\n+/g, '')
         );


### PR DESCRIPTION
This PR introduces error handling to the preloading process on SSR. Currently, if the preloading fails, it can lead to application termination. With this change, the app will no longer break. Instead, it will insert a fallback `<link>` stylesheet tag for entered url, allowing the browser to attempt to load the fonts in its standard manner. This ensures the app remains stable and functional, even in the event of external service issues.

### Example

```tsx
<GoogleFontsOptimizer
	url={[
		"https://fonts.googleapis.com/css2?family=SIMULATE_FAILURE",
		"https://fonts.googleapis.com/css2?family=Inter:wght@200;400;500;700&display=swap"
	]}
>
</GoogleFontsOptimizer>
```

![example](https://github.com/sebholstein/astro-google-fonts-optimizer/assets/1501013/4c26e209-16f7-4601-81a6-54214edc2ae0)

---

### Error

This was the error that terminated my app, for some reason the Google service went unstable.

<img width="843" alt="image" src="https://github.com/sebholstein/astro-google-fonts-optimizer/assets/1501013/94dfc85f-e649-44de-9774-0b0f9d4270d7">
