### PR TITLE
Add support for Google font compatible drop-ins such as fonts.bunny.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ This will create the following output:
 </head>
 ```
 
-If you're using a Google Fonts compatible dropin such as [Bunny Fonts](https://fonts.bunny.net/), you can specify the `preconnect`-URL via the `preconnectUrl` prop like this:
+If you're using a Google Fonts compatible drop-in such as [Bunny Fonts](https://fonts.bunny.net/), you can specify the `preconnect`-URL via the `preconnectUrl` prop like this:
 
 ```
-        <GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" />
+<GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" />
 ```
 
-This will result in the correct url to be included:
+If left empty, the preconnect-URL will default to `https://fonts.gstatic.com`. Otherwise, the given value is used:
 
 ```
 <link rel="preconnect" href="https://fonts.bunny.net" crossorigin="anonymous">

--- a/README.md
+++ b/README.md
@@ -46,4 +46,16 @@ This will create the following output:
 </head>
 ```
 
+If you're using a Google Fonts compatible dropin such as [Bunny Fonts](https://fonts.bunny.net/), you can specify the `preconnect`-URL via the `preconnectUrl` prop like this:
+
+```
+        <GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" />
+```
+
+This will result in the correct url to be included:
+
+```
+<link rel="preconnect" href="https://fonts.bunny.net" crossorigin="anonymous">
+```
+
 You can read about this performance optimization in [this excellent blog post](https://dev.to/ekafyi/first-impressions-on-next-js-automatic-font-optimization-32a1).

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -3,9 +3,11 @@ import { downloadFontCSS } from "./font-utils";
 
 export interface Props {
     url: string[] | string;
+    preconnectUrl?: string;
 }
 const props = Astro.props as Props;
 const urls = Array.isArray(props.url) ? props.url : [props.url];
+const preconnect = props.preconnectUrl ?? 'https://fonts.gstatic.com';
 
 const contents = await Promise.all(
     urls.map(async (url) => {
@@ -19,8 +21,9 @@ const contents = await Promise.all(
 )
 ---
 
-{contents.length > 0 &&
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />}
+{contents.length > 0 && preconnect && (
+  <link rel="preconnect" href={preconnect} crossorigin="anonymous" />
+)}
 {contents.map(content => {
     if (content.css) {
         return (


### PR DESCRIPTION
Hi @sebholstein , this is a nice plugin, thanks!

We're using [Bunny Fonts](https://fonts.bunny.net) as GDPR and privacy focused Google Fonts alternative. For this to work, I changed your code slightly to include a prop for setting the `href`-attribute of the preconnect link and amended the `README.md` to reflect this. Since Bunny Fonts is a compatible drop-in replacement for Google Fonts, no other changes were needed.

Feel free to merge, ask for changes or simply close if it doesn't suit you.

