### PR TITLE
Added cache and retry attemps on fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ import { GoogleFontsOptimizer } from "astro-google-fonts-optimizer";
 ```
 
 This will create the following output:
-```html
+
+```
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
@@ -49,7 +50,10 @@ This will create the following output:
 If you're using a Google Fonts compatible drop-in such as [Bunny Fonts](https://fonts.bunny.net/), you can specify the `preconnect`-URL via the `preconnectUrl` prop like this:
 
 ```jsx
-<GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" />
+<GoogleFontsOptimizer
+  url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap"
+  preconnectUrl="https://fonts.bunny.net"
+/>
 ```
 
 If left empty, the preconnect-URL will default to `https://fonts.gstatic.com`. Otherwise, the given value is used:
@@ -58,12 +62,16 @@ If left empty, the preconnect-URL will default to `https://fonts.gstatic.com`. O
 <link rel="preconnect" href="https://fonts.bunny.net" crossorigin="anonymous">
 ```
 
-If first fetch of a font will fail, it'll be refetched three times by default in 100 milliseconds interval
+If first fetch of a font will fail, it'll be refetched three times by default in 100 milliseconds intervals
 You can configure this by setting `retryInterval` and `retryAttempts` props
+
 ```jsx
-<GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" retryInterval="200" retryAttempts="5" />
+<GoogleFontsOptimizer
+  url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap"
+  preconnectUrl="https://fonts.bunny.net"
+  retryInterval="200"
+  retryAttempts="5"
+/>
 ```
 
 You can read about this performance optimization in [this excellent blog post](https://dev.to/ekafyi/first-impressions-on-next-js-automatic-font-optimization-32a1).
-
-

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import { GoogleFontsOptimizer } from "astro-google-fonts-optimizer";
 
 This will create the following output:
 
-```
+```html
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">

--- a/README.md
+++ b/README.md
@@ -48,14 +48,22 @@ This will create the following output:
 
 If you're using a Google Fonts compatible drop-in such as [Bunny Fonts](https://fonts.bunny.net/), you can specify the `preconnect`-URL via the `preconnectUrl` prop like this:
 
-```
+```jsx
 <GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" />
 ```
 
 If left empty, the preconnect-URL will default to `https://fonts.gstatic.com`. Otherwise, the given value is used:
 
-```
+```jsx
 <link rel="preconnect" href="https://fonts.bunny.net" crossorigin="anonymous">
 ```
 
+If first fetch of a font will fail, it'll be refetched three times by default in 100 milliseconds interval
+You can configure this by setting `retryInterval` and `retryAttempts` props
+```jsx
+<GoogleFontsOptimizer url="https://fonts.bunny.net/css2?family=Inter:wght@200;400;500;700&display=swap" preconnectUrl="https://fonts.bunny.net" retryInterval="200" retryAttempts="5" />
+```
+
 You can read about this performance optimization in [this excellent blog post](https://dev.to/ekafyi/first-impressions-on-next-js-automatic-font-optimization-32a1).
+
+

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -11,12 +11,8 @@ const preconnect = props.preconnectUrl ?? 'https://fonts.gstatic.com';
 
 const contents = await Promise.all(
     urls.map(async (url) => {
-        try {
-            const css = await downloadFontCSS(url);
-            return { css }
-        } catch (err) {
-            return { url }
-        }
+      const css = await downloadFontCSS(url);
+      return { css }
     })
 )
 ---
@@ -25,14 +21,11 @@ const contents = await Promise.all(
   <link rel="preconnect" href={preconnect} crossorigin="anonymous" />
 )}
 {contents.map(content => {
-    if (content.css) {
         return (
             <>
                 <style set:html={content.css} is:inline>
                 </style>
             </>
         )
-    }
 
-    return <link href={content.url} rel="stylesheet" />
 })}

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -1,20 +1,26 @@
 ---
-import { downloadFontCSS } from "./font-utils";
+import { initialise } from "./font-utils";
 
 export interface Props {
     url: string[] | string;
     preconnectUrl?: string;
+    retryAttempts?: number;
+    retryInterval?: number;
 }
-const props = Astro.props as Props;
-const urls = Array.isArray(props.url) ? props.url : [props.url];
-const preconnect = props.preconnectUrl ?? 'https://fonts.gstatic.com';
 
+const { url, retryInterval, retryAttempts, preconnectUrl } = Astro.props as Props;
+
+const urls = Array.isArray(url) ? url : [url];
+const preconnect = preconnectUrl ?? 'https://fonts.gstatic.com';
+
+const downloadFontCSS = initialise(retryAttempts,retryInterval)
 const contents = await Promise.all(
     urls.map(async (url) => {
         try {
             const css = await downloadFontCSS(url);
             return { css }
         } catch (err) {
+            console.error(`\nError while downloading "${url}".\n${err}\n`)
             return { url }
         }
     })

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -13,7 +13,7 @@ const { url, retryInterval, retryAttempts, preconnectUrl } = Astro.props as Prop
 const urls = Array.isArray(url) ? url : [url];
 const preconnect = preconnectUrl ?? 'https://fonts.gstatic.com';
 
-const downloadFontCSS = initialise(retryAttempts,retryInterval)
+const downloadFontCSS = initialise(retryAttempts, retryInterval)
 const contents = await Promise.all(
     urls.map(async (url) => {
         try {

--- a/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
+++ b/packages/astro-google-fonts-optimizer/GoogleFontsOptimizer.astro
@@ -11,8 +11,12 @@ const preconnect = props.preconnectUrl ?? 'https://fonts.gstatic.com';
 
 const contents = await Promise.all(
     urls.map(async (url) => {
-      const css = await downloadFontCSS(url);
-      return { css }
+        try {
+            const css = await downloadFontCSS(url);
+            return { css }
+        } catch (err) {
+            return { url }
+        }
     })
 )
 ---
@@ -21,11 +25,14 @@ const contents = await Promise.all(
   <link rel="preconnect" href={preconnect} crossorigin="anonymous" />
 )}
 {contents.map(content => {
+    if (content.css) {
         return (
             <>
                 <style set:html={content.css} is:inline>
                 </style>
             </>
         )
+    }
 
+    return <link href={content.url} rel="stylesheet" />
 })}

--- a/packages/astro-google-fonts-optimizer/font-utils.ts
+++ b/packages/astro-google-fonts-optimizer/font-utils.ts
@@ -32,8 +32,7 @@ export async function downloadFontCSS(url: string): Promise<string> {
   const fontDownloads: string[] = [];
   for await (const agent of userAgents) {
     const fontData = await cachedFetch(agent, url).catch((err) => {
-      throw new Error(`Failed to download ${url}: 
-${err}`);
+      throw new Error(`Failed to download ${url}:\n${err}`);
     });
     fontDownloads.push(fontData);
   }

--- a/packages/astro-google-fonts-optimizer/font-utils.ts
+++ b/packages/astro-google-fonts-optimizer/font-utils.ts
@@ -31,7 +31,10 @@ const cachedFetch = cacheWrapper(tenacityWrapper(fetchFunc, 3, 500));
 export async function downloadFontCSS(url: string): Promise<string> {
   const fontDownloads: string[] = [];
   for await (const agent of userAgents) {
-    const fontData = await cachedFetch(agent, url);
+    const fontData = await cachedFetch(agent, url).catch((err) => {
+      throw new Error(`Failed to download ${url}: 
+${err}`);
+    });
     fontDownloads.push(fontData);
   }
   return fontDownloads.join(' ');

--- a/packages/astro-google-fonts-optimizer/font-utils.ts
+++ b/packages/astro-google-fonts-optimizer/font-utils.ts
@@ -26,12 +26,13 @@ const fetchFunc = <Args extends (typeof userAgents)[number]>(
     })
     .then((t) => t.replace(/  +/g, '').replace(/\t+/g, '').replace(/\n+/g, ''));
 
-const cachedFetch = cacheWrapper(tenacityWrapper(fetchFunc, 3, 100));
+const cachedFetch = cacheWrapper(tenacityWrapper(fetchFunc, 3, 500));
 
 export async function downloadFontCSS(url: string): Promise<string> {
   const fontDownloads: string[] = [];
-  for await (const a of userAgents) {
-    fontDownloads.push(await cachedFetch(a, url)); // for await (const)
+  for await (const agent of userAgents) {
+    const fontData = await cachedFetch(agent, url);
+    fontDownloads.push(fontData);
   }
   return fontDownloads.join(' ');
 }

--- a/packages/astro-google-fonts-optimizer/font-utils.ts
+++ b/packages/astro-google-fonts-optimizer/font-utils.ts
@@ -26,7 +26,7 @@ const fetchFunc = <Args extends (typeof userAgents)[number]>(
     })
     .then((t) => t.replace(/  +/g, '').replace(/\t+/g, '').replace(/\n+/g, ''));
 
-const cachedFetch = cacheWrapper(tenacityWrapper(fetchFunc, 3, 500));
+const cachedFetch = cacheWrapper(tenacityWrapper(fetchFunc, 3, 100));
 
 export async function downloadFontCSS(url: string): Promise<string> {
   const fontDownloads: string[] = [];

--- a/packages/astro-google-fonts-optimizer/package.json
+++ b/packages/astro-google-fonts-optimizer/package.json
@@ -15,6 +15,7 @@
     "index.js",
     "index.d.ts",
     "font-utils.ts",
+    "wrappers.ts",
     "GoogleFontsOptimizer.astro",
     "../../README.md"
   ],

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -1,9 +1,9 @@
-type Fn<Args extends unknown[], ReturnType> = (
+type Fn<Args extends any[], ReturnType> = (
   ...args: Args
 ) => Promise<ReturnType>;
 
 // Define the cacheWrapper function with type safety
-export const cacheWrapper = <Args extends unknown[], ReturnType>(
+export const cacheWrapper = <Args extends any[], ReturnType>(
   fn: Fn<Args, ReturnType>,
 ): Fn<Args, ReturnType> => {
   const cache = new Map<string, ReturnType>();

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -16,6 +16,7 @@ export const cacheWrapper = <T extends unknown[], R>(
     return data;
   };
 };
+
 export const tenacityWrapper = <T extends any[], R>(
   fn: Fn<T, R>,
   retries: number,

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -24,18 +24,14 @@ export const tenacityWrapper = <T extends any[], R>(
   return async (...args: T): Promise<R> => {
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    for (let attempt = 0; attempt < retries; attempt++) {
       try {
         return await fn(...args);
       } catch (error) {
         lastError = error;
-        console.error(`Attempt ${attempt + 1} failed. Retrying...`);
-        if (attempt < retries) {
-          await new Promise((resolve) => setTimeout(resolve, delay));
-        }
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
-
     // If all retries failed, throw the last error
     throw lastError;
   };

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -9,10 +9,8 @@ export const cacheWrapper = <T extends unknown[], R>(
     const cacheKey = JSON.stringify(args);
     const cachedData = cache.get(cacheKey);
     if (cachedData) {
-      console.log('cache hit');
       return cachedData;
     }
-    console.log('cache miss');
     const data = await fn(...args);
     cache.set(cacheKey, data);
     return data;

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -1,11 +1,13 @@
-type Fn<T extends unknown[], R> = (...args: T) => Promise<R>;
+type Fn<Args extends unknown[], ReturnType> = (
+  ...args: Args
+) => Promise<ReturnType>;
 
 // Define the cacheWrapper function with type safety
-export const cacheWrapper = <T extends unknown[], R>(
-  fn: Fn<T, R>,
-): Fn<T, R> => {
-  const cache = new Map<string, R>();
-  return async (...args: T): Promise<R> => {
+export const cacheWrapper = <Args extends unknown[], ReturnType>(
+  fn: Fn<Args, ReturnType>,
+): Fn<Args, ReturnType> => {
+  const cache = new Map<string, ReturnType>();
+  return async (...args: Args): Promise<ReturnType> => {
     const cacheKey = JSON.stringify(args);
     const cachedData = cache.get(cacheKey);
     if (cachedData) {
@@ -17,12 +19,12 @@ export const cacheWrapper = <T extends unknown[], R>(
   };
 };
 
-export const tenacityWrapper = <T extends any[], R>(
-  fn: Fn<T, R>,
+export const tenacityWrapper = <Args extends any[], ReturnType>(
+  fn: Fn<Args, ReturnType>,
   retries: number,
   delay: number = 0,
-): Fn<T, R> => {
-  return async (...args: T): Promise<R> => {
+): Fn<Args, ReturnType> => {
+  return async (...args: Args): Promise<ReturnType> => {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt < retries; attempt++) {

--- a/packages/astro-google-fonts-optimizer/wrappers.ts
+++ b/packages/astro-google-fonts-optimizer/wrappers.ts
@@ -1,0 +1,44 @@
+type Fn<T extends unknown[], R> = (...args: T) => Promise<R>;
+
+// Define the cacheWrapper function with type safety
+export const cacheWrapper = <T extends unknown[], R>(
+  fn: Fn<T, R>,
+): Fn<T, R> => {
+  const cache = new Map<string, R>();
+  return async (...args: T): Promise<R> => {
+    const cacheKey = JSON.stringify(args);
+    const cachedData = cache.get(cacheKey);
+    if (cachedData) {
+      console.log('cache hit');
+      return cachedData;
+    }
+    console.log('cache miss');
+    const data = await fn(...args);
+    cache.set(cacheKey, data);
+    return data;
+  };
+};
+export const tenacityWrapper = <T extends any[], R>(
+  fn: Fn<T, R>,
+  retries: number,
+  delay: number = 0,
+): Fn<T, R> => {
+  return async (...args: T): Promise<R> => {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        return await fn(...args);
+      } catch (error) {
+        lastError = error;
+        console.error(`Attempt ${attempt + 1} failed. Retrying...`);
+        if (attempt < retries) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+    }
+
+    // If all retries failed, throw the last error
+    throw lastError;
+  };
+};


### PR DESCRIPTION
Partially fixes this issue: https://github.com/sebholstein/astro-google-fonts-optimizer/issues/1 with in-memory cache

Also sometimes I had crashes for unknown reasons during dev and build so I added that it'll retry refetching url in case of failure three times by default

npm package for testing: 
https://www.npmjs.com/package/@herob191/astro-google-fonts-optimizer

Also I wonder if this
```js
const contents = await Promise.all(
    urls.map(async (url) => {
        try {
            const css = await downloadFontCSS(url);
            return { css }
        } catch (err) {
            return { url }
        }
    })
)
```
Can be replaced with this
```js
const contents = await Promise.all(
    urls.map(async (url) => {
        
            const css = await downloadFontCSS(url);
            return { css }
    })
)
```

And then this
```jsx
{contents.map(content => {
    if (content.css) {
        return (
            <>
                <style set:html={content.css} is:inline>
                </style>
            </>
        )
    }

    return <link href={content.url} rel="stylesheet" />
})}
```
with this:
```jsx
{contents.map(content => (
            <>
                <style set:html={content.css} is:inline>
                </style>
            </>
        
)}
```
Or is there more purpouse to it I don't see yet?